### PR TITLE
Fix malformed NotAPICall message

### DIFF
--- a/CLASSES/class_API.php
+++ b/CLASSES/class_API.php
@@ -747,8 +747,6 @@ class API
  */
 class API_NotApiCall extends CustomException
 {
-    protected $message = 'This is not an API call. Please see ' . 
-        'https://github.com/CCHits/Website/wiki/Using-the-API ' .
-        'for details on the API';
+    protected $message = "This is not an API call. Please see https:\/\/github.com\/CCHits\/Website\/wiki\/Using-the-API for details on the API";
     protected $code    = 255;
 }


### PR DESCRIPTION
Message contained a URL with unescaped forward slashes, causing some API calls to fail.